### PR TITLE
Added an option to disable input path validation in hadoop

### DIFF
--- a/docs/guides/configs-hadoopy-runners.rst
+++ b/docs/guides/configs-hadoopy-runners.rst
@@ -64,3 +64,8 @@ Options available to hadoop runner only
     Scratch space on HDFS (default is ``tmp/``). This path does not need to be
     fully qualified with ``hdfs://`` URIs because it's understood that it has
     to be on HDFS.
+
+**check_hadoop_input_paths** (:option:`--skip-hadoop-input-check`)
+    Option to skip the input path check. With this option all input paths
+    to the runner will be passed straight through, without their existence
+    being validated.

--- a/mrjob/hadoop.py
+++ b/mrjob/hadoop.py
@@ -114,6 +114,7 @@ class HadoopRunnerOptionStore(RunnerOptionStore):
         'hadoop_bin',
         'hadoop_home',
         'hdfs_scratch_dir',
+        'check_hadoop_input_paths',
     ]))
 
     COMBINERS = combine_dicts(RunnerOptionStore.COMBINERS, {
@@ -156,6 +157,7 @@ class HadoopRunnerOptionStore(RunnerOptionStore):
         return combine_dicts(super_opts, {
             'hadoop_home': os.environ.get('HADOOP_HOME'),
             'hdfs_scratch_dir': 'tmp/mrjob',
+            'check_hadoop_input_paths': True,
         })
 
 
@@ -244,9 +246,10 @@ class HadoopJobRunner(MRJobRunner):
             if path == '-':
                 continue  # STDIN always exists
 
-            if not self.path_exists(path):
-                raise AssertionError(
-                    'Input path %s does not exist!' % (path,))
+            if self._opts['check_hadoop_input_paths']:
+                if not self.path_exists(path):
+                    raise AssertionError(
+                        'Input path %s does not exist!' % (path,))
 
     def _add_job_files_for_upload(self):
         """Add files needed for running the job (setup and input)

--- a/mrjob/options.py
+++ b/mrjob/options.py
@@ -245,6 +245,10 @@ def add_hadoop_opts(opt_group):
             '--hdfs-scratch-dir', dest='hdfs_scratch_dir',
             default=None,
             help='Scratch space on HDFS (default is tmp/)'),
+        opt_group.add_option(
+            '--skip-hadoop-input-check', dest='check_hadoop_input_paths',
+            default=True, action='store_false',
+            help='Skip the check that ensures all input paths exist'),
     ]
 
 

--- a/tests/test_hadoop.py
+++ b/tests/test_hadoop.py
@@ -245,6 +245,9 @@ class HadoopJobRunnerEndToEndTestCase(MockHadoopTestCase):
         with patch.object(pty, 'fork', side_effect=OSError()):
             self._test_end_to_end()
 
+    def test_end_to_end_with_disabled_input_path_check(self):
+        self._test_end_to_end(['--skip-hadoop-input-check'])
+
 
 class StreamingArgsTestCase(EmptyMrjobConfTestCase):
 


### PR DESCRIPTION
_Mirror implementation of yelp/mrjob#583_

I've added a new option that disabled input path checking for the hadoop runner when set to `False`. The option is named `check_hadoop_input_paths` unsurprisingly.
