### PR TITLE
Silence protocol warnings

### DIFF
--- a/mrjob/job.py
+++ b/mrjob/job.py
@@ -915,9 +915,6 @@ class MRJob(MRJobLauncher):
         objects. Default behavior is to return an instance of
         :py:attr:`INPUT_PROTOCOL`.
         """
-        if not isinstance(self.INPUT_PROTOCOL, type):
-            log.warn('INPUT_PROTOCOL should be a class, not %s' %
-                     self.INPUT_PROTOCOL)
         return self.INPUT_PROTOCOL()
 
     def internal_protocol(self):
@@ -925,9 +922,6 @@ class MRJob(MRJobLauncher):
         Default behavior is to return an instance of
         :py:attr:`INTERNAL_PROTOCOL`.
         """
-        if not isinstance(self.INTERNAL_PROTOCOL, type):
-            log.warn('INTERNAL_PROTOCOL should be a class, not %s' %
-                     self.INTERNAL_PROTOCOL)
         return self.INTERNAL_PROTOCOL()
 
     def output_protocol(self):
@@ -935,9 +929,6 @@ class MRJob(MRJobLauncher):
         lines. Default behavior is to return an instance of
         :py:attr:`OUTPUT_PROTOCOL`.
         """
-        if not isinstance(self.OUTPUT_PROTOCOL, type):
-            log.warn('OUTPUT_PROTOCOL should be a class, not %s' %
-                     self.OUTPUT_PROTOCOL)
         return self.OUTPUT_PROTOCOL()
 
     #: Protocol for reading input to the first mapper in your job.

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -890,7 +890,13 @@ class ProtocolTypeTestCase(unittest.TestCase):
         def OUTPUT_PROTOCOL(self):
             return JSONProtocol()
 
-    def test_attrs_should_be_classes(self):
+    class BadJob(MRJob):
+
+        INPUT_PROTOCOL = object()
+        INTERNAL_PROTOCOL = object()
+        OUTPUT_PROTOCOL = object()
+
+    def test_attrs_dont_need_to_be_classes(self):
         with no_handlers_for_logger('mrjob.job'):
             stderr = StringIO()
             log_to_stream('mrjob.job', stderr)
@@ -899,9 +905,16 @@ class ProtocolTypeTestCase(unittest.TestCase):
             self.assertIsInstance(job.internal_protocol(), JSONProtocol)
             self.assertIsInstance(job.output_protocol(), JSONProtocol)
             logs = stderr.getvalue()
-            self.assertIn('INPUT_PROTOCOL should be a class', logs)
-            self.assertIn('INTERNAL_PROTOCOL should be a class', logs)
-            self.assertIn('OUTPUT_PROTOCOL should be a class', logs)
+            # Protocols only need to be callable.
+            self.assertNotIn('INPUT_PROTOCOL should be a class', logs)
+            self.assertNotIn('INTERNAL_PROTOCOL should be a class', logs)
+            self.assertNotIn('OUTPUT_PROTOCOL should be a class', logs)
+
+    def test_attrs_need_to_be_callable(self):
+        job = self.StrangeJob()
+        self.assertRaises(TypeError, job.input_protocol())
+        self.assertRaises(TypeError, job.internal_protocol())
+        self.assertRaises(TypeError, job.output_protocol())
 
 
 class StepsTestCase(unittest.TestCase):


### PR DESCRIPTION
A protocol doesn’t need to be a class, it only needs to be callable.

Ping @tarnfeld @icio 
