### PR TITLE
Proxy straight through to the underlying copy_from_local method

### DIFF
--- a/mrjob/fs/composite.py
+++ b/mrjob/fs/composite.py
@@ -65,8 +65,7 @@ class CompositeFilesystem(Filesystem):
         return self._do_action('write', path, content)
 
     def copy_from_local(self, path, local_file):
-        with open(local_file, "r") as fd:
-            return self._do_action('write', path, fd)
+        return self._do_action('copy_from_local', path, local_file)
 
     def du(self, path_glob):
         return self._do_action('du', path_glob)


### PR DESCRIPTION
No need to do any fancy stuff through `_write` when we an use real `copy_from_local` implementations.